### PR TITLE
update setup.py - Python3 compatible builtins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        import builtins
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 


### PR DESCRIPTION
Dear all,
Thank you for all the great work on scikit bio!
This is a minor fix for Python 3 compatibility, which uses the builtins module rather than **builtins**.
See https://docs.python.org/3/library/builtins.html .
I noticed this as I was trying to set up my new package omicexperiment which depends on sci-kit bio, and currently fails on 'python setup.py install' which I suspect is due to that particular line that uses **builtins** 

```
AttributeError: 'dict' object has no attribute '__NUMPY_SETUP__'
```

Cheers,
Ahmed
